### PR TITLE
Don't chown user files and add 1Password support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ The SSH auth socket is a Unix socket used by the SSH agent to communicate with o
 **macOS:**
 ```bash
 docker run --rm -it \
-  -v "$HOME/.ssh:/ssh" \
+  -v "$HOME/.ssh:/ssh:ro" \
+  -v "$HOME/.ssh/known_hosts:/ssh/known_hosts:rw" \
   -v "$(pwd):/ansible" \
   -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock" \
   -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" \
@@ -125,7 +126,8 @@ Notice how we're matching the `SSH_AUTH_SOCK` to the host's socket. This is nece
 **Linux:**
 ```bash
 docker run --rm -it \
-  -v "$HOME/.ssh:/ssh" \
+  -v "$HOME/.ssh:/ssh:ro" \
+ -v "$HOME/.ssh/known_hosts:/ssh/known_hosts:rw" \
   -v "$(pwd):/ansible" \
   -v "$SSH_AUTH_SOCK:$SSH_AUTH_SOCK" \
   -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK" \

--- a/src/rootfs/entrypoint.sh
+++ b/src/rootfs/entrypoint.sh
@@ -85,6 +85,13 @@ if { [ ! -z "${PUID}" ] && [ "${PUID}" != "$default_uid" ]; } || { [ ! -z "${PGI
 
     debug_print "Changing ownership of all files and directories..."
     chown "${PUID}:${PGID}" "/home/${run_as_user}" "${ANSIBLE_HOME}"
+
+fi
+
+if [ "$SSH_AUTH_SOCK" ]; then
+    debug_print "Creating a symbolic link to the SSH Agent socket in the 1Password directory..."
+    mkdir -p "/home/${run_as_user}/Library/Group Containers/2BUA8C4S2C.com.1password/t"
+    ln -sf "$SSH_AUTH_SOCK" "/home/${run_as_user}/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 fi
 
 # Run the command as the unprivileged user if PUID, PGID are set, or if RUN_AS_USER is different from default

--- a/src/rootfs/entrypoint.sh
+++ b/src/rootfs/entrypoint.sh
@@ -84,7 +84,7 @@ if { [ ! -z "${PUID}" ] && [ "${PUID}" != "$default_uid" ]; } || { [ ! -z "${PGI
     groupmod -g "${PGID}" "${run_as_user}" 2>&1 >/dev/null || echo "Error changing group ID."
 
     debug_print "Changing ownership of all files and directories..."
-    chown "${PUID}:${PGID}" "/home/${run_as_user}" "/home/${run_as_user}/.ssh" "${ANSIBLE_HOME}" "/ssh"
+    chown "${PUID}:${PGID}" "/home/${run_as_user}" "${ANSIBLE_HOME}"
 fi
 
 # Run the command as the unprivileged user if PUID, PGID are set, or if RUN_AS_USER is different from default


### PR DESCRIPTION
# What this PR does
This PR brings important changes.

### We don't change permissions on host files anymore
Before we were running commands that could potentially change permissions on mounted directories. We no longer do that.

We also encourage people to use `ro` (read only) mounts for the SSH folder, but only mount `known_hosts` as `rw` (read-write).

For example:
```
-v "$HOME/.ssh:/ssh:ro"
-v "$HOME/.ssh/known_hosts:/ssh/known_hosts:rw"
 ```

## We added 1Password support
We spent a lot of time optimizing the images to work with 1password for Mac: https://serversideup.net/how-to-get-ssh-to-work-with-1password-docker-desktop-macos-within-a-container/