### PR TITLE
Add Kerberos support to Debian

### DIFF
--- a/ansible-versions.yml
+++ b/ansible-versions.yml
@@ -86,6 +86,7 @@ operating_system_distributions:
           - "git"
           - "gosu"
           - "jq"
+          - "krb5-user"
           - "less"
           - "libffi-dev"
           - "libhdf5-dev"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -61,7 +61,7 @@ RUN serversideup-dep-install-alpine ${PACKAGE_DEPENDENCIES} && \
     # Install Ansible and additional dependencies
     echo "🤓 Installing ${BUILD_ANSIBLE_VARIATION}==${BUILD_ANSIBLE_PATCH_VERSION}" && \
     pip3 install --no-cache-dir "${BUILD_ANSIBLE_VARIATION}==${BUILD_ANSIBLE_PATCH_VERSION}" && \
-    pip3 install --no-cache-dir ansible-lint passlib requests python-dateutil && \
+    pip3 install --no-cache-dir ansible-lint passlib requests python-dateutil 'pywinrm[kerberos]>=0.4.0' 'pypsrp[kerberos]<=1.0.0' && \
     \
     # Verify Ansible installation
     ansible --version

--- a/src/rootfs/usr/local/bin/serversideup-dep-install-debian
+++ b/src/rootfs/usr/local/bin/serversideup-dep-install-debian
@@ -6,7 +6,7 @@ set -oe
 ###################################################
 # This script installs debian packages that are passed to it
 
-DEBIAN_FRONTEND=noninteractive
+export DEBIAN_FRONTEND=noninteractive
 script_name="serversideup-dep-install-debian"
 
 ############


### PR DESCRIPTION
- Add OS and Python packages to Debian necessary for Ansible Kerberos authentication
- Correctly export `DEBIAN_FRONTEND` variable for dpkg to pickup